### PR TITLE
fix: Pull in updated elastic chart

### DIFF
--- a/elasticsearch/experiment.yaml
+++ b/elasticsearch/experiment.yaml
@@ -95,7 +95,7 @@ spec:
       setupTasks:
       - name: elasticsearch
         helmChart: stable/elasticsearch
-        helmChartVersion: "1.31.1"
+        helmChartVersion: "1.32.4"
         helmValues:
         - name: cluster.name
           value: rally-demo


### PR DESCRIPTION
This brings in the change from apps/v1beta1 -> appsv1 to provide compatibility for kube 1.16+

Signed-off-by: Brad Beam <brad.beam@b-rad.info>