### PR TITLE
feat: Add test for recipes during ci

### DIFF
--- a/.ci/install_kustomize.sh
+++ b/.ci/install_kustomize.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -xe
+
+[[ -f /usr/local/bin/kustomize ]] && exit 0
+
+echo "Install kustomize"
+curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | \
+  bash
+sudo mv ./kustomize /usr/local/bin/kustomize

--- a/.ci/locust-metrics/ci.sh
+++ b/.ci/locust-metrics/ci.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -xe
+
+echo "Create experiment and application"
+kustomize build .ci/locust-metrics | kubectl apply -f -
+echo "Create new trial"
+redskyctl generate trial \
+  --assign worker_replicas=1 \
+  --assign voting_replicas=1 \
+  --assign voting_cpu=250 \
+  --assign worker_cpu=250 \
+  --assign db_cpu=250 \
+  --assign redis_cpu=250 \
+  --assign worker_memory=250 \
+  --assign voting_memory=250 \
+  --assign db_memory=250 \
+  --assign redis_memory=250 \
+  -f <(kubectl get experiment locust-metrics -o yaml) | \
+    kubectl create -f -
+kubectl get trial -o wide
+# Change this back to a higher value when we can schedule the trial
+echo "Wait for trial to complete (600s timeout)"
+kubectl wait trial \
+  -l redskyops.dev/experiment=locust-metrics \
+  --for condition=redskyops.dev/trial-complete \
+  --timeout 600s
+kubectl get trial -o wide
+kubectl get pods -o wide -l redskyops.dev/experiment=locust-metrics
+echo "Cleanup experiment and application"
+kustomize build locust-metrics | kubectl delete -f -

--- a/.ci/locust-metrics/kustomization.yaml
+++ b/.ci/locust-metrics/kustomization.yaml
@@ -1,0 +1,43 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../locust-metrics
+
+patches:
+- path: ./resources_patch.json
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: db
+- path: ./resources_patch.json
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: redis
+- path: ./resources_patch.json
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: result-service
+- path: ./resources_patch.json
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: result-exporter
+- path: ./resources_patch.json
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: voting-service
+- path: ./resources_patch.json
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: worker

--- a/.ci/locust-metrics/resources_patch.json
+++ b/.ci/locust-metrics/resources_patch.json
@@ -1,0 +1,12 @@
+[
+  {
+   "op": "remove",
+   "path": "/spec/template/spec/containers/0/resources"
+  },
+  {
+   "op": "replace",
+   "path": "/spec/strategy",
+   "value": { "type": "Recreate" }
+  }
+]
+

--- a/.ci/setup_redskyctl.sh
+++ b/.ci/setup_redskyctl.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -xe
+
+curl -s -LO https://github.com/redskyops/redskyops-controller/releases/download/v1.6.1/redskyctl-linux-amd64.tar.gz
+tar -xf redskyctl-linux-amd64.tar.gz
+chmod 755 redskyctl
+sudo mv redskyctl /usr/local/bin
+redskyctl init --wait

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,40 @@
+name: Pull Request workflow
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        experiment:
+          - locust-metrics
+          #- voting-webapp
+          #- jvm
+          #- parallel-trials
+          #- postgres
+          #- elasticsearch
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: KinD (Kubernetes in Docker) Initialization
+        uses: helm/kind-action@v1.0.0-rc.1
+        with:
+          version: v0.8.1
+      - name: Download and Setup redskyctl
+        run: |
+          .ci/setup_redskyctl.sh
+      - name: Install kustomize
+        run: |
+          .ci/install_kustomize.sh
+      - name: Run sample trial for ${{ matrix.experiment }}
+        run: |
+          .ci/${{ matrix.experiment }}/ci.sh
+      - name: The job has failed
+        if: ${{ failure() }}
+        run: |
+          kubectl get trial,experiment,svc,pod -o wide
+          kubectl get pods -o wide
+


### PR DESCRIPTION
This introduces a "simple" test for the locust web app recipe. Additional tests will be added for all other recipes if this is a pattern we want to follow.

We run through:
- kind setup
- patch/deploy resources
- generate a static trial

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>